### PR TITLE
fix(linux): use IP*_PMTUDISC_PROBE

### DIFF
--- a/code/main.c
+++ b/code/main.c
@@ -22,10 +22,12 @@
 
 #ifdef __linux__
     typedef int sock_optval_t;
-    #define IPV4_DONTFRAG_OPTNAME IP_MTU_DISCOVER
-    #define IPV4_DONTFRAG_OPTVAL IP_PMTUDISC_DO
-    #define IPV6_DONTFRAG_OPTNAME IPV6_MTU_DISCOVER
-    #define IPV6_DONTFRAG_OPTVAL IPV6_PMTUDISC_DO
+    #define IPV4_MTU_DISCOVER_OPTNAME IP_MTU_DISCOVER
+    #define IPV4_MTU_DISCOVER_OPTVAL IP_PMTUDISC_PROBE
+    #define IPV6_MTU_DISCOVER_OPTNAME IPV6_MTU_DISCOVER
+    #define IPV6_MTU_DISCOVER_OPTVAL IPV6_PMTUDISC_PROBE
+    #define IPV6_DONTFRAG_OPTNAME IPV6_DONTFRAG
+    #define IPV6_DONTFRAG_OPTVAL 1
 #elif defined(__APPLE__)
     typedef int sock_optval_t;
     #define IPV4_DONTFRAG_OPTNAME IP_DONTFRAG
@@ -147,12 +149,21 @@ int main(int argc, char *argv[]) {
     #endif
 
     if(should_set_ipv4_df) {
+        #ifdef __linux__
+        sock_optval_t opt_val = IPV4_MTU_DISCOVER_OPTVAL;
+        if (setsockopt(sock, IPPROTO_IP, IPV4_MTU_DISCOVER_OPTNAME, &opt_val, sizeof(opt_val)) < 0) {
+            perror("setsockopt ipv4 mtu discover");
+            close(sock);
+            return 1;
+        }
+        #else
         sock_optval_t opt_val = IPV4_DONTFRAG_OPTVAL;
         if (setsockopt(sock, IPPROTO_IP, IPV4_DONTFRAG_OPTNAME, &opt_val, sizeof(opt_val)) < 0) {
             perror("setsockopt ipv4 dontfrag");
             close(sock);
             return 1;
         }
+        #endif
     }
 
     if(net_type == IPV6 || net_type == DUAL) {
@@ -162,6 +173,14 @@ int main(int argc, char *argv[]) {
             close(sock);
             return 1;
         }
+        #ifdef __linux__
+        opt_val = IPV6_MTU_DISCOVER_OPTVAL;
+        if (setsockopt(sock, IPPROTO_IP, IPV6_MTU_DISCOVER_OPTNAME, &opt_val, sizeof(opt_val)) < 0) {
+            perror("setsockopt ipv6 mtu discover");
+            close(sock);
+            return 1;
+        }
+        #endif
     }
 
     for (int i = 0; i < PACKET_COUNT; i++) {

--- a/code/main.c
+++ b/code/main.c
@@ -26,8 +26,6 @@
     #define IPV4_MTU_DISCOVER_OPTVAL IP_PMTUDISC_PROBE
     #define IPV6_MTU_DISCOVER_OPTNAME IPV6_MTU_DISCOVER
     #define IPV6_MTU_DISCOVER_OPTVAL IPV6_PMTUDISC_PROBE
-    #define IPV6_DONTFRAG_OPTNAME IPV6_DONTFRAG
-    #define IPV6_DONTFRAG_OPTVAL 1
 #elif defined(__APPLE__)
     typedef int sock_optval_t;
     #define IPV4_DONTFRAG_OPTNAME IP_DONTFRAG
@@ -167,16 +165,17 @@ int main(int argc, char *argv[]) {
     }
 
     if(net_type == IPV6 || net_type == DUAL) {
-        sock_optval_t opt_val = IPV6_DONTFRAG_OPTVAL;
-        if (setsockopt(sock, IPPROTO_IPV6, IPV6_DONTFRAG_OPTNAME, &opt_val, sizeof(opt_val)) < 0) {
-            perror("setsockopt");
+        #ifdef __linux__
+        sock_optval_t opt_val = IPV6_MTU_DISCOVER_OPTVAL;
+        if (setsockopt(sock, IPPROTO_IP, IPV6_MTU_DISCOVER_OPTNAME, &opt_val, sizeof(opt_val)) < 0) {
+            perror("setsockopt ipv6 mtu discover");
             close(sock);
             return 1;
         }
-        #ifdef __linux__
-        opt_val = IPV6_MTU_DISCOVER_OPTVAL;
-        if (setsockopt(sock, IPPROTO_IP, IPV6_MTU_DISCOVER_OPTNAME, &opt_val, sizeof(opt_val)) < 0) {
-            perror("setsockopt ipv6 mtu discover");
+        #else
+        sock_optval_t opt_val = IPV6_DONTFRAG_OPTVAL;
+        if (setsockopt(sock, IPPROTO_IPV6, IPV6_DONTFRAG_OPTNAME, &opt_val, sizeof(opt_val)) < 0) {
+            perror("setsockopt");
             close(sock);
             return 1;
         }

--- a/code/main.c
+++ b/code/main.c
@@ -22,10 +22,10 @@
 
 #ifdef __linux__
     typedef int sock_optval_t;
-    #define IPV4_MTU_DISCOVER_OPTNAME IP_MTU_DISCOVER
-    #define IPV4_MTU_DISCOVER_OPTVAL IP_PMTUDISC_PROBE
-    #define IPV6_MTU_DISCOVER_OPTNAME IPV6_MTU_DISCOVER
-    #define IPV6_MTU_DISCOVER_OPTVAL IPV6_PMTUDISC_PROBE
+    #define IPV4_DONTFRAG_OPTNAME IP_MTU_DISCOVER
+    #define IPV4_DONTFRAG_OPTVAL IP_PMTUDISC_PROBE
+    #define IPV6_DONTFRAG_OPTNAME IPV6_MTU_DISCOVER
+    #define IPV6_DONTFRAG_OPTVAL IPV6_PMTUDISC_PROBE
 #elif defined(__APPLE__)
     typedef int sock_optval_t;
     #define IPV4_DONTFRAG_OPTNAME IP_DONTFRAG
@@ -147,39 +147,21 @@ int main(int argc, char *argv[]) {
     #endif
 
     if(should_set_ipv4_df) {
-        #ifdef __linux__
-        sock_optval_t opt_val = IPV4_MTU_DISCOVER_OPTVAL;
-        if (setsockopt(sock, IPPROTO_IP, IPV4_MTU_DISCOVER_OPTNAME, &opt_val, sizeof(opt_val)) < 0) {
-            perror("setsockopt ipv4 mtu discover");
-            close(sock);
-            return 1;
-        }
-        #else
         sock_optval_t opt_val = IPV4_DONTFRAG_OPTVAL;
         if (setsockopt(sock, IPPROTO_IP, IPV4_DONTFRAG_OPTNAME, &opt_val, sizeof(opt_val)) < 0) {
             perror("setsockopt ipv4 dontfrag");
             close(sock);
             return 1;
         }
-        #endif
     }
 
     if(net_type == IPV6 || net_type == DUAL) {
-        #ifdef __linux__
-        sock_optval_t opt_val = IPV6_MTU_DISCOVER_OPTVAL;
-        if (setsockopt(sock, IPPROTO_IP, IPV6_MTU_DISCOVER_OPTNAME, &opt_val, sizeof(opt_val)) < 0) {
-            perror("setsockopt ipv6 mtu discover");
-            close(sock);
-            return 1;
-        }
-        #else
         sock_optval_t opt_val = IPV6_DONTFRAG_OPTVAL;
         if (setsockopt(sock, IPPROTO_IPV6, IPV6_DONTFRAG_OPTNAME, &opt_val, sizeof(opt_val)) < 0) {
             perror("setsockopt");
             close(sock);
             return 1;
         }
-        #endif
     }
 
     for (int i = 0; i < PACKET_COUNT; i++) {

--- a/draft-seemann-tsvwg-udp-fragmentation.md
+++ b/draft-seemann-tsvwg-udp-fragmentation.md
@@ -85,13 +85,19 @@ IPv4 sockets and prevent fragmentation on IPv6 sockets.
 
 ## Linux
 
-Linux uses the socket option of level IPPROTO_IP with name IP_MTU_DISCOVER with
-value IP_PMTUDISC_DO for IPv4.
+In order to send packets larger than the observed Path MTU and to disable
+Linux's own Path MTU Discovery, one uses the socket option of level IPPROTO_IP
+with name IP_MTU_DISCOVER with value IP_PMTUDISC_PROBE for IPv4, and socket
+option of level IPPROTO_IPV6 with name IPV6_MTU_DISCOVER with value
+IPV6_PMTUDISC_PROBE for IPv6.
 
-For IPv6, IPV6_MTU_DISCOVER with a value of IPV6_PMTUDISC_DO is used for the
-IPPROTO_IPV6 level.
+In addition, to receive errors when sending packets larger than the interface
+MTU, one sets the socket option of level IPPROTO_IP with name IP_DONTFRAG
+for IPv4 and socket option of level IPPROTO_IPV6 with name IPV6_DONTFRAG on
+IPv6.
 
-For dual-stack sockets, both socket options can be set independently.
+For dual-stack sockets, both IPv4 and IPv6 socket options can be set
+independently.
 
 
 ## Apple

--- a/draft-seemann-tsvwg-udp-fragmentation.md
+++ b/draft-seemann-tsvwg-udp-fragmentation.md
@@ -85,17 +85,22 @@ IPv4 sockets and prevent fragmentation on IPv6 sockets.
 
 ## Linux
 
-In order to disable Linux's own Path MTU Discovery, one uses the socket option
-of level IPPROTO_IP with name IP_MTU_DISCOVER with value IP_PMTUDISC_PROBE for
-IPv4, and socket option of level IPPROTO_IPV6 with name IPV6_MTU_DISCOVER with
-value IPV6_PMTUDISC_PROBE for IPv6.
+PMTUD behavior is controlled via the IP_MTU_DISCOVER and IPV6_MTU_DISCOVER
+socket option on level IPPROTO_IP and IPPROTO_IPV6. A value of IP_PMTUDISC_DO
+and IPV6_PMTUDISC_DO turns on the DF bit, and enables the processing of ICMP
+packets by the kernel. A value of IP_PMTUDISC_PROBE and IPV6_PMTUDISC_PROBE
+turns on the DF bit, and disables the processing of ICMP packets by the kernel.
+
+Given that IP_PMTUDISC_DO and IPV6_PMTUDISC_DO prevent sending datagrams larger
+than the observed path MTU and are prone to ICMP NEEDFRAG attacks, one should
+use IP_PMTUDISC_PROBE and IPV6_PMTUDISC_PROBE.
 
 For dual-stack sockets, both IPv4 and IPv6 socket options can be set
 independently.
 
 In addition, for IPv6, to prevent local fragmentation when sending packets
-larger than the interface MTU, one sets the socket option of level IPPROTO_IPV6
-with name IPV6_DONTFRAG.
+larger than the interface MTU, set the socket option of level IPPROTO_IPV6 with
+name IPV6_DONTFRAG.
 
 
 ## Apple

--- a/draft-seemann-tsvwg-udp-fragmentation.md
+++ b/draft-seemann-tsvwg-udp-fragmentation.md
@@ -90,12 +90,12 @@ of level IPPROTO_IP with name IP_MTU_DISCOVER with value IP_PMTUDISC_PROBE for
 IPv4, and socket option of level IPPROTO_IPV6 with name IPV6_MTU_DISCOVER with
 value IPV6_PMTUDISC_PROBE for IPv6.
 
+For dual-stack sockets, both IPv4 and IPv6 socket options can be set
+independently.
+
 In addition, for IPv6, to prevent local fragmentation when sending packets
 larger than the interface MTU, one sets the socket option of level IPPROTO_IPV6
 with name IPV6_DONTFRAG.
-
-For dual-stack sockets, both IPv4 and IPv6 socket options can be set
-independently.
 
 
 ## Apple

--- a/draft-seemann-tsvwg-udp-fragmentation.md
+++ b/draft-seemann-tsvwg-udp-fragmentation.md
@@ -98,10 +98,6 @@ use IP_PMTUDISC_PROBE and IPV6_PMTUDISC_PROBE.
 For dual-stack sockets, both IPv4 and IPv6 socket options can be set
 independently.
 
-In addition, for IPv6, to prevent local fragmentation when sending packets
-larger than the interface MTU, set the socket option of level IPPROTO_IPV6 with
-name IPV6_DONTFRAG.
-
 
 ## Apple
 

--- a/draft-seemann-tsvwg-udp-fragmentation.md
+++ b/draft-seemann-tsvwg-udp-fragmentation.md
@@ -85,11 +85,10 @@ IPv4 sockets and prevent fragmentation on IPv6 sockets.
 
 ## Linux
 
-In order to send packets larger than the observed Path MTU and to disable
-Linux's own Path MTU Discovery, one uses the socket option of level IPPROTO_IP
-with name IP_MTU_DISCOVER with value IP_PMTUDISC_PROBE for IPv4, and socket
-option of level IPPROTO_IPV6 with name IPV6_MTU_DISCOVER with value
-IPV6_PMTUDISC_PROBE for IPv6.
+In order to disable Linux's own Path MTU Discovery, one uses the socket option
+of level IPPROTO_IP with name IP_MTU_DISCOVER with value IP_PMTUDISC_PROBE for
+IPv4, and socket option of level IPPROTO_IPV6 with name IPV6_MTU_DISCOVER with
+value IPV6_PMTUDISC_PROBE for IPv6.
 
 In addition, for IPv6, to prevent local fragmentation when sending packets
 larger than the interface MTU, one sets the socket option of level IPPROTO_IPV6

--- a/draft-seemann-tsvwg-udp-fragmentation.md
+++ b/draft-seemann-tsvwg-udp-fragmentation.md
@@ -92,8 +92,8 @@ packets by the kernel. A value of IP_PMTUDISC_PROBE and IPV6_PMTUDISC_PROBE
 turns on the DF bit, and disables the processing of ICMP packets by the kernel.
 
 Given that IP_PMTUDISC_DO and IPV6_PMTUDISC_DO prevent sending datagrams larger
-than the observed path MTU and are prone to ICMP NEEDFRAG attacks, one should
-use IP_PMTUDISC_PROBE and IPV6_PMTUDISC_PROBE.
+than the observed path MTU and are prone to the Blind Performance-Degrading
+attack ({{!RFC5927}}), one should use IP_PMTUDISC_PROBE and IPV6_PMTUDISC_PROBE.
 
 For dual-stack sockets, both IPv4 and IPv6 socket options can be set
 independently.

--- a/draft-seemann-tsvwg-udp-fragmentation.md
+++ b/draft-seemann-tsvwg-udp-fragmentation.md
@@ -92,7 +92,7 @@ packets by the kernel. A value of IP_PMTUDISC_PROBE and IPV6_PMTUDISC_PROBE
 turns on the DF bit, and disables the processing of ICMP packets by the kernel.
 
 Given that IP_PMTUDISC_DO and IPV6_PMTUDISC_DO prevent sending datagrams larger
-than the observed path MTU and are prone to the Blind Performance-Degrading
+than the observed path MTU and are prone to the Blind Performance-Degrading ICMP
 attack ({{!RFC5927}}), one should use IP_PMTUDISC_PROBE and IPV6_PMTUDISC_PROBE.
 
 For dual-stack sockets, both IPv4 and IPv6 socket options can be set

--- a/draft-seemann-tsvwg-udp-fragmentation.md
+++ b/draft-seemann-tsvwg-udp-fragmentation.md
@@ -91,10 +91,9 @@ with name IP_MTU_DISCOVER with value IP_PMTUDISC_PROBE for IPv4, and socket
 option of level IPPROTO_IPV6 with name IPV6_MTU_DISCOVER with value
 IPV6_PMTUDISC_PROBE for IPv6.
 
-In addition, to receive errors when sending packets larger than the interface
-MTU, one sets the socket option of level IPPROTO_IP with name IP_DONTFRAG
-for IPv4 and socket option of level IPPROTO_IPV6 with name IPV6_DONTFRAG on
-IPv6.
+In addition, for IPv6, to prevent local fragmentation when sending packets
+larger than the interface MTU, one sets the socket option of level IPPROTO_IPV6
+with name IPV6_DONTFRAG.
 
 For dual-stack sockets, both IPv4 and IPv6 socket options can be set
 independently.


### PR DESCRIPTION
1. Use `IP*_PMTUDISC_PROBE` instead of `IP*_PMTUDISC_DO`, in order to disable Linux's own PMTUD and to send packets larger than the observed Path MTU.
2. Use `IP*_DONTFRAG` to receive errors when sending packets larger than the interface MTU.
---
Fixes #13 

@marten-seemann and @ralith this is my understanding of the socket options. Thoughts?